### PR TITLE
Clarify apple music metadata for downloads

### DIFF
--- a/bot/helpers/buttons/settings.py
+++ b/bot/helpers/buttons/settings.py
@@ -142,6 +142,12 @@ def core_buttons():
                 text=f"Video Upload: {'Document' if bot_set.video_as_document else 'Media'}",
                 callback_data='vidUploadType'
             )
+        ],
+        [
+            InlineKeyboardButton(
+                text=f"Extract Embedded Cover: {'True' if bot_set.extract_embedded_cover else 'False'}",
+                callback_data='toggleExtractCover'
+            )
         ]
     ]
     inline_keyboard += main_button + close_button

--- a/bot/helpers/utils.py
+++ b/bot/helpers/utils.py
@@ -629,7 +629,7 @@ async def extract_audio_metadata(file_path: str) -> dict:
                 'artist': audio.get('\xa9ART', ['Unknown Artist'])[0],
                 'album': audio.get('\xa9alb', ['Unknown Album'])[0],
                 'duration': int(audio.info.length),
-                'thumbnail': extract_cover_art(audio, file_path)
+                'thumbnail': extract_cover_art(audio, file_path) if getattr(bot_set, 'extract_embedded_cover', True) else None
             }
         else:
             # Handle other audio formats like mp3, flac, etc.
@@ -639,7 +639,7 @@ async def extract_audio_metadata(file_path: str) -> dict:
                 'artist': audio.get('artist', ['Unknown Artist'])[0],
                 'album': audio.get('album', ['Unknown Album'])[0],
                 'duration': int(audio.info.length),
-                'thumbnail': extract_cover_art(audio, file_path) if hasattr(audio, 'pictures') else None
+                'thumbnail': (extract_cover_art(audio, file_path) if hasattr(audio, 'pictures') and getattr(bot_set, 'extract_embedded_cover', True) else None)
             }
     except Exception as e:
         LOGGER.error(f"Audio metadata extraction failed: {str(e)}")
@@ -661,7 +661,7 @@ async def extract_video_metadata(file_path: str) -> dict:
                 'title': video.get('\xa9nam', ['Unknown'])[0],
                 'artist': video.get('\xa9ART', ['Unknown Artist'])[0],
                 'duration': int(video.info.length),
-                'thumbnail': extract_cover_art(video, file_path),
+                'thumbnail': extract_cover_art(video, file_path) if getattr(bot_set, 'extract_embedded_cover', True) else None,
                 'width': video.get('width', [1920])[0],
                 'height': video.get('height', [1080])[0]
             }
@@ -693,7 +693,7 @@ async def extract_apple_metadata(file_path: str) -> dict:
                 'artist': audio.get('artist', ['Unknown Artist'])[0],
                 'album': audio.get('album', ['Unknown Album'])[0],
                 'duration': int(audio.info.length),
-                'thumbnail': extract_cover_art(audio, file_path) if hasattr(audio, 'pictures') else None
+                'thumbnail': (extract_cover_art(audio, file_path) if hasattr(audio, 'pictures') and getattr(bot_set, 'extract_embedded_cover', True) else None)
             }
     except Exception as e:
         LOGGER.error(f"Apple metadata extraction failed: {str(e)}")

--- a/bot/modules/settings.py
+++ b/bot/modules/settings.py
@@ -378,6 +378,19 @@ async def video_upload_type_cb(client, cb:CallbackQuery):
             pass
 
 
+@Client.on_callback_query(filters.regex(pattern=r"^toggleExtractCover$"))
+async def toggle_extract_cover_cb(client, cb:CallbackQuery):
+    if await check_user(cb.from_user.id, restricted=True):
+        try:
+            bot_set.extract_embedded_cover = not bool(getattr(bot_set, 'extract_embedded_cover', True))
+            set_db.set_variable('EXTRACT_EMBEDDED_COVER', bot_set.extract_embedded_cover)
+        except Exception:
+            pass
+        try:
+            await core_cb(client, cb)
+        except:
+            pass
+
 @Client.on_callback_query(filters.regex(pattern=r"^linkOption"))
 async def link_option_cb(client, cb:CallbackQuery):
     if await check_user(cb.from_user.id, restricted=True):

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -109,6 +109,13 @@ class BotSettings:
         video_doc, _ = set_db.get_variable('VIDEO_AS_DOCUMENT')
         self.video_as_document = bool(video_doc) if isinstance(video_doc, bool) else (str(video_doc).lower() == 'true')
 
+        # New: whether to extract embedded cover artwork
+        try:
+            val = __getvalue__('EXTRACT_EMBEDDED_COVER') or Config.EXTRACT_EMBEDDED_COVER
+        except Exception:
+            val = Config.EXTRACT_EMBEDDED_COVER
+        self.extract_embedded_cover = _to_bool(val)
+
         self.clients = []
         self.download_history = download_history
 

--- a/config.py
+++ b/config.py
@@ -73,6 +73,8 @@ class Config:
     PLAYLIST_ZIP          = getenv("PLAYLIST_ZIP", "False")               # True or False
     ARTIST_ZIP            = getenv("ARTIST_ZIP", "False")                 # True or False
     RCLONE_LINK_OPTIONS   = getenv("RCLONE_LINK_OPTIONS", "Index")        # False, Index, RCLONE, or Both
+    # New: control whether to extract embedded cover art from files
+    EXTRACT_EMBEDDED_COVER = getenv("EXTRACT_EMBEDDED_COVER", "True")      # True or False
 
     # Apple Wrapper Scripts
     APPLE_WRAPPER_SETUP_PATH = getenv("APPLE_WRAPPER_SETUP_PATH", "/usr/src/app/downloader/setup_wrapper.sh")

--- a/sample.env
+++ b/sample.env
@@ -53,3 +53,5 @@ UPLOAD_MODE=Telegram
 # PLAYLIST_ZIP: True or False
 # ARTIST_ZIP: True or False
 # RCLONE_LINK_OPTIONS: False, Index, RCLONE, or Both
+# New: control whether to extract embedded cover art from files for uploads
+EXTRACT_EMBEDDED_COVER=True


### PR DESCRIPTION
Adds a user-controllable setting to toggle extraction of embedded cover art from downloaded media files.

---
<a href="https://cursor.com/background-agent?bcId=bc-46be3d09-c748-43de-9584-72b41cf014ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46be3d09-c748-43de-9584-72b41cf014ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

